### PR TITLE
Update git url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.3.1",
   "repository": {
     "type": "git",
-    "url": "git://github.com/livewire/vue-support.git"
+    "url": "git://github.com/livewire/vue.git"
   },
   "scripts": {
     "watch": "npx rollup -c -w",


### PR DESCRIPTION
So it can be clicked in `yarn outdated` output. Right now I get 404 for livewire/vue-support.

<img width="891" alt="image" src="https://user-images.githubusercontent.com/846625/92989053-c6496200-f4d9-11ea-836a-b38952319dab.png">
